### PR TITLE
Update vendor prefixes for transition property

### DIFF
--- a/css/dashicons.css
+++ b/css/dashicons.css
@@ -25,8 +25,8 @@
 	font-weight: normal;
 	font-style: normal;
 	vertical-align: top;
-	-moz-transition: color .1s ease-in 0;
 	-webkit-transition: color .1s ease-in 0;
+	transition: color .1s ease-in 0;
 	text-align: center;
 }
 


### PR DESCRIPTION
Since we let Autoprefixer handler prefixes in core we have to add the non-prefixed version too. With our browser settings -moz prefixed version isn't needed, so we can remove it.
