### PR TITLE
Added CSS classes for 4 new icons 

### DIFF
--- a/css/dashicons.css
+++ b/css/dashicons.css
@@ -448,6 +448,10 @@
 	content: "\f164";
 }
 
+.dashicons-grid-view:before {
+	content: "\f509";
+}
+
 
 /* WPorg specific icons: Jobs, Profiles, WordCamps */
 
@@ -880,14 +884,10 @@
 	content: "\f328";
 }
 
-.dashicons-recipe:before {
+.dashicons-index-card:before {
 	content: "\f510";
 }
 
 .dashicons-carrot:before {
 	content: "\f511";
-}
-
-.dashicons-grid:before {
-	content: "\f509";
 }


### PR DESCRIPTION
Added CSS classes for 4 new icons: new calendar (f508), grid (f509), recipe card (f510) and carrot (f511)
I am unfamiliar with the grid icon, so I added it to the end of the list. I can move it if you like.
