### PR TITLE
Add prefix to React component

### DIFF
--- a/react/dashicon/inc/index-footer.jsx
+++ b/react/dashicon/inc/index-footer.jsx
@@ -4,7 +4,7 @@
 			return null;
 		}
 
-		const iconClass = [ 'dashicon', icon, className ].filter( Boolean ).join( ' ' );
+		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 
 		return (
 			<svg className={ iconClass } xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">


### PR DESCRIPTION
This is a teensy PR that only affects the built react component. It simply changes the output so that icons have a properly prefixed icon class, i.e. `dashicons-button` instead of plainly `button`, so as to avoid CSS bleed.