### PR TITLE
Readme: no more external dependencies, more details (update after #215)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,33 @@
 
 Dashicons, the WordPress admin icon font. For the official documentation, please refer to the [WordPress Developer Resource](https://developer.wordpress.org/resource/dashicons/).
 
+
+### Icon requests
+
 For new icon requests, please [create a new issue on this GitHub repository](https://github.com/WordPress/dashicons/issues/new). If you'd like to work an an icon request, [check out our WIP Dashicons style guide](https://make.wordpress.org/design/dashicons-style-guide/).
 
-For any bugs that appear within WordPress core, please [create a new ticket on WordPress Trac](https://core.trac.wordpress.org/newticket). Use the "Administration" component and the "ui" focus when creating the new ticket, and be sure to include "Dashicons" somewhere in the text of the ticket.
+You can join Dashicons discussion and get help on the [official WordPress Slack chat](https://make.wordpress.org/chat/). Just register and join the #design-dashicons channel.
 
-Dashicons is licensed under [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html), or any later version with [font exception](http://www.gnu.org/licenses/gpl-faq.html#FontException).
 
-## Building / Installing
+### WordPress Bugs
 
-To build Dashicons, make sure you have <a href="https://nodejs.org">Node JS</a> installed. The next steps are platform specific. Once all steps for your platform are complete, you can type `npm run build` on the commandline to generate the minified SVG files and sprite.
+For any bugs that appear within WordPress Core, please [create a new ticket on WordPress Trac](https://core.trac.wordpress.org/newticket). Use the "Administration" component and the "ui" focus when creating the new ticket, and be sure to include "Dashicons" somewhere in the text of the ticket.
 
-### Mac
 
-Start by installing <a href="https://brew.sh/">Brew</a>. You may need to use `sudo` for `brew`, depending on your setup.
+## Setup
 
-Then on the commandline:
+To build Dashicons, make sure you have <a href="https://nodejs.org">Node JS</a> installed. Then type `npm run build` on the commandline to generate the minified SVG files and sprite.
 
-```
-brew install ttfautohint fontforge --with-python
-npm install
-```
-
-### Linux
-
-On the commandline:
-
-```
-sudo apt-get install fontforge ttfautohint
-npm install
-```
-
-### Windows
-
-On the commandline:
-
-```
-npm install
-```
-
-Then [install `ttfautohint`](http://www.freetype.org/ttfautohint/#download) (optional).
-
-Then install `fontforge`.
-* Download and install [fontforge](http://fontforge.github.io/en-US/downloads/windows/).
-* Add `C:\Program Files (x86)\FontForgeBuilds\bin` to your `PATH` environment variable.
 
 ## Adding an icon
 
-Once you're installed, to add an icon, save an SVG in the `svg` folder, then run the `npm run build` command on the commandline.
+Once you're installed, to add an icon, save an SVG in the `sources/svg` folder, then run the `npm run build` command on the commandline.
+
+If you want to add your icon to the Dashicons library, open a new Pull Request here with the new SVG icon, and wait a review.
+
+If you're adding an icon for [Gutenberg](https://github.com/WordPress/gutenberg/) specifically, add it inside the `sources/svg/gutenberg` folder. It will be processed for everything but the font files.
+
+
+## License
+
+Dashicons is licensed under [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html), or any later version with [font exception](http://www.gnu.org/licenses/gpl-faq.html#FontException).


### PR DESCRIPTION
I've updated the readme:

* after #215 as the setup is now simpler (just node)
* added a paragraph on how to propose an icon on GitHub (might be expanded later)
* added some more structure

## To test

See the readme [here](https://github.com/WordPress/dashicons/blob/9f2efdf053a01ec507f1843bd32783feb32b4555/README.md).