### PR TITLE
Added focusable=false to prevent IE 11 giving focus to the icons

### DIFF
--- a/react/index.jsx
+++ b/react/index.jsx
@@ -829,6 +829,7 @@ export default class Dashicon extends wp.element.Component {
 			<svg 
 				aria-hidden
 				role="img"
+				focusable="false"
 				className={ iconClass }
 				xmlns="http://www.w3.org/2000/svg"
 				width={ size }


### PR DESCRIPTION
This was done in the Gutenberg repo, and recommended we do it here.