### PR TITLE
added focusable=false to react/index.jsx for ie11 support

### DIFF
--- a/react/index.jsx
+++ b/react/index.jsx
@@ -838,6 +838,7 @@ export default class Dashicon extends wp.element.Component {
 			<svg 
 				aria-hidden
 				role="img"
+				focusable="false"
 				className={ iconClass }
 				xmlns="http://www.w3.org/2000/svg"
 				width={ size }


### PR DESCRIPTION
Adding this back in as it got lost somehow.