### PR TITLE
Update license in `package.json` to adhere to SPDX v3.0 specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/WordPress/dashicons"
   },
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "files": [
     "build/index.js",
     "build/example.js"


### PR DESCRIPTION
See also:
• https://spdx.org/news/news/2018/01/license-list-30-released
• https://spdx.org/licenses/
• WordPress Ticket [#43032](https://core.trac.wordpress.org/ticket/43032)