### PR TITLE
Add helper SCSS file to React component

### DIFF
--- a/react/style.scss
+++ b/react/style.scss
@@ -1,0 +1,4 @@
+svg.dashicon {
+	fill: currentColor;
+	outline: none;
+}

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -6,6 +6,11 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 !!! */
 
 /**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
  * External dependencies
  */
 export default class Dashicon extends wp.element.Component {


### PR DESCRIPTION
This adds a very simple SCSS file to the React component, with a few rules for any SVG icon that uses the `dashicon` class.

The fill rule makes sure the icon inherits the `color` of the parent element. This means for example that if you put a dashicon inside a link, the dashicon will have the same blue color as the link, even the purple color when visited.

The outline rule ensures that the icon is uses as just that, a decorative element, that inherits the focus style of the parent.

Creating this PR to help solve a problem in Gutenberg and future React projects that use Dashicons. See also https://github.com/WordPress/gutenberg/pull/5352#issuecomment-371150594