### PR TITLE
Add Cover Image icon

### DIFF
--- a/sources/svg/gutenberg/cover-image.svg
+++ b/sources/svg/gutenberg/cover-image.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<g>
+	<path d="M2.2,1h15.5C18.4,1,19,1.6,19,2.2v11.5c0,0.7-0.6,1.2-1.2,1.2H2.2C1.6,15,1,14.4,1,13.8V2.2C1,1.6,1.6,1,2.2,1z M17,13V3H3
+		v10H17z M13,9c0,0,0-5,3-5v7c0,0.6-0.4,1-1,1H5c-0.6,0-1-0.4-1-1V7c2,0,3,4,3,4s1-4,3-4S13,9,13,9z"/>
+</g>
+<rect x="4" y="17" width="12" height="2"/>
+</svg>


### PR DESCRIPTION
Right now in Gutenberg, the icon for the Cover Image block is the same as that for the Image block. This PR adds a new icon for the Cover Image block, fixing https://github.com/WordPress/gutenberg/issues/5516#issuecomment-372048002. The idea is based on the icon for full-wide, which shows text below the image in a more widescreen format, indicating that it's a "bolder" image.

Thoughts?

If you like it I need to run grunt first.

<img width="681" alt="screen shot 2018-03-12 at 09 50 37" src="https://user-images.githubusercontent.com/1204802/37273813-2e249dc0-25db-11e8-8d58-2ca0215147d2.png">

<img width="742" alt="screen shot 2018-03-12 at 09 50 43" src="https://user-images.githubusercontent.com/1204802/37273819-2f80a178-25db-11e8-8b07-0975110aca0e.png">
