### PR TITLE
Update handlebars to v4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-svgmin": "^2.0.1",
     "grunt-webfont": "^1.6.0",
     "grunt-svgstore": "^0.3.6",
-    "handlebars": "^2.0.0",
+    "handlebars": "^4.0.11",
     "jit-grunt": "^0.10.0",
     "load-grunt-tasks": "^3.5.2",
     "multiline": "^0.3.4",


### PR DESCRIPTION
This PR seeks to update the handlebars.js library from 2.x to 4.x

https://github.com/wycats/handlebars.js/compare/v2.0.0...v4.0.11

Currently this is untested and will need some testing to ensure the generated templates produce what is currently expected.

Even though _handlebars_ is only a _devDependancy_ this PR removes a _security_ warning currently displayed on this repo.