### PR TITLE
Update React template to import Component from @wordpress/element

### DIFF
--- a/react/index.jsx
+++ b/react/index.jsx
@@ -8,7 +8,17 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-export default class Dashicon extends wp.element.Component {
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return (
 			this.props.icon !== nextProps.icon ||

--- a/react/index.jsx
+++ b/react/index.jsx
@@ -15,9 +15,6 @@ import { Component } from '@wordpress/element';
  */
 import './style.scss';
 
-/**
- * External dependencies
- */
 export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return (

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -6,6 +6,11 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 !!! */
 
 /**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -13,7 +18,7 @@ import './style.scss';
 /**
  * External dependencies
  */
-export default class Dashicon extends wp.element.Component {
+export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return (
 			this.props.icon !== nextProps.icon ||

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -15,9 +15,6 @@ import { Component } from '@wordpress/element';
  */
 import './style.scss';
 
-/**
- * External dependencies
- */
 export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return (


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/3952

This pull request seeks to update the React template to reference the [`@wordpress/element` npm package](https://www.npmjs.com/package/@wordpress/element) as a dependency, rather than rely on the existence of a global `wp.element.Component`.

Notes:

- I had many other unrelated changes when trying to generate the new build on a clean copy of the branch. Unsure if these are related to one or the other or both of (a) the project expecting a specific version of Node / npm or (b) icons having been added without a new build generated.
- There's several other improvements that could be made to this build process:
   - Not assuming that the consumer uses `@wordpress/element` (e.g. also React)
   - Not assuming that the consumer is using a Webpack plugin capable of transforming `.scss` imports (i.e. inline CSS or at least building CSS as part of build process)