### PR TITLE
Add support for react native

### DIFF
--- a/react/path.js
+++ b/react/path.js
@@ -1,0 +1,1 @@
+export default ( props ) => ( <path { ...props } /> );

--- a/react/path.native.js
+++ b/react/path.native.js
@@ -1,0 +1,3 @@
+import { Path } from 'react-native-svg';
+
+export default ( props ) => ( <Path { ...props } /> );

--- a/react/svg.js
+++ b/react/svg.js
@@ -1,0 +1,5 @@
+export default ( props ) => (
+	<svg { ...props } >
+		{ props.children }
+	</svg>
+);

--- a/react/svg.native.js
+++ b/react/svg.native.js
@@ -1,0 +1,7 @@
+import Svg from 'react-native-svg';
+
+export default ( props ) => (
+	<Svg width={ props.width } height={ props.height } >
+		{ props.children }
+	</Svg>
+);

--- a/sources/react/index-footer.jsx
+++ b/sources/react/index-footer.jsx
@@ -7,7 +7,7 @@
 		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
 
 		return (
-			<svg
+			<SVG
 				aria-hidden
 				role="img"
 				focusable="false"
@@ -18,7 +18,7 @@
 				viewBox="0 0 20 20"
 			>
 				<path d={ path } />
-			</svg>
+			</SVG>
 		);
 	}
 }

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -9,6 +9,8 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import SVG from './svg';
+import Path from './path';
 
 export default class Dashicon extends Component {
 	shouldComponentUpdate( nextProps ) {


### PR DESCRIPTION
This PR updates the generation of the React code in order to be compatible with React Native too.

The way it work is to create variants for svg and path elements for the react native work.

It leverages this SVG react native [library](https://github.com/react-native-community/react-native-svg).

The library only needs to be added to the React Native projects that use DashIcon, so it doesn't create a dependency on the React web projects.