### PR TITLE
Adding changes for parity with gutenberg repo.

### DIFF
--- a/sources/react/index-footer.jsx
+++ b/sources/react/index-footer.jsx
@@ -4,7 +4,7 @@
 			return null;
 		}
 
-		const iconClass = [ 'dashicon', 'dashicons-' + icon, className ].filter( Boolean ).join( ' ' );
+		const iconClass = getIconClassName( icon, className, ariaPressed );
 
 		return (
 			<SVG
@@ -16,8 +16,9 @@
 				width={ size }
 				height={ size }
 				viewBox="0 0 20 20"
+				{ ...extraProps }
 			>
-				<path d={ path } />
+				<Path d={ path } />
 			</SVG>
 		);
 	}

--- a/sources/react/index-header.jsx
+++ b/sources/react/index-header.jsx
@@ -9,20 +9,16 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import SVG from './svg';
-import Path from './path';
+
+/**
+ * Internal dependencies
+ */
+import { Path, SVG } from '../primitives';
+import { getIconClassName } from './icon-class';
 
 export default class Dashicon extends Component {
-	shouldComponentUpdate( nextProps ) {
-		return (
-			this.props.icon !== nextProps.icon ||
-			this.props.size !== nextProps.size ||
-			this.props.className !== nextProps.className
-		);
-	}
-
 	render() {
-		const { icon, className, size = 20 } = this.props;
+		const { icon, size = 20, className, ariaPressed, ...extraProps } = this.props;
 		let path;
 
 		switch ( icon ) {


### PR DESCRIPTION
This PR adds the changes made to the [Dashicon/index.js](https://github.com/WordPress/gutenberg/blob/828fe40798b4d9b4a4d344b68eb0e2f62632ee8c/packages/components/src/dashicon/index.js) file on the gutenberg repo.

There are two [new files](https://github.com/WordPress/gutenberg/tree/828fe40798b4d9b4a4d344b68eb0e2f62632ee8c/packages/components/src/dashicon) (`icon-class.js` and `icon-class.native.js`). I'm not sure if those should be added here too.
 
@jasmussen - If you can take a look at this would be great. Thank you!