### PR TITLE
Add missing `:before` to two icons

### DIFF
--- a/icon-font/css-template.css
+++ b/icon-font/css-template.css
@@ -67,7 +67,8 @@
 	content: "\f211";
 }
 
-.dashicons-exerpt-view {
+/* This is a typo, but was previously released. It should remain for backward compatibility. See https://core.trac.wordpress.org/ticket/30832. */
+.dashicons-exerpt-view:before {
 	content: "\f164";
 }
 
@@ -79,7 +80,7 @@
 	content: "\f109";
 }
 
-.dashicons-post-trash {
+.dashicons-post-trash:before {
 	content: "\f182";
 }
 

--- a/icon-font/css/dashicons.css
+++ b/icon-font/css/dashicons.css
@@ -1138,7 +1138,8 @@
 	content: "\f211";
 }
 
-.dashicons-exerpt-view {
+/* This is a typo, but was previously released. It should remain for backward compatibility. See https://core.trac.wordpress.org/ticket/30832. */
+.dashicons-exerpt-view:before {
 	content: "\f164";
 }
 
@@ -1150,7 +1151,7 @@
 	content: "\f109";
 }
 
-.dashicons-post-trash {
+.dashicons-post-trash:before {
 	content: "\f182";
 }
 

--- a/icon-font/dashicons.html
+++ b/icon-font/dashicons.html
@@ -1191,7 +1191,8 @@ body {
 	content: "\f211";
 }
 
-.dashicons-exerpt-view {
+/* This is a typo, but was previously released. It should remain for backward compatibility. See https://core.trac.wordpress.org/ticket/30832. */
+.dashicons-exerpt-view:before {
 	content: "\f164";
 }
 
@@ -1203,7 +1204,7 @@ body {
 	content: "\f109";
 }
 
-.dashicons-post-trash {
+.dashicons-post-trash:before {
 	content: "\f182";
 }
 


### PR DESCRIPTION
The `.dashicons-exerpt-view` and `.dashicons-post-trash` manually specified icon classes were missing `:before`. Also, it should be clarified that the misspelled class definition should remain for backward compatibility.