### PR TITLE
Remove redundant font-face declaration from font CSS template

### DIFF
--- a/icon-font/css-template.css
+++ b/icon-font/css-template.css
@@ -5,15 +5,7 @@
  */
 
 /* stylelint-disable function-url-quotes, declaration-colon-newline-after */
-<% if (fontfaceStyles) { %>
-<% if (fontSrc1 && embed.length) { %>@font-face {
-	font-family: <%= fontFamilyName %>;
-	src: <%= fontSrc1 %>;
-	font-weight: 400;
-	font-style: normal;
-}
-
-<% } %>@font-face {
+<% if (fontfaceStyles) { %>@font-face {
 	font-family: <%= fontFamilyName %>;<% if (fontSrc1) { %>
 	src: <%= fontSrc1 %>;<% }%>
 	src: <%= fontSrc2 %>;

--- a/icon-font/css/dashicons.css
+++ b/icon-font/css/dashicons.css
@@ -5,14 +5,6 @@
  */
 
 /* stylelint-disable function-url-quotes, declaration-colon-newline-after */
-
-@font-face {
-	font-family: dashicons;
-	src: url("../fonts/dashicons.eot?b3b1c452bbecfc7ad76f6023ace474d0");
-	font-weight: 400;
-	font-style: normal;
-}
-
 @font-face {
 	font-family: dashicons;
 	src: url("../fonts/dashicons.eot?b3b1c452bbecfc7ad76f6023ace474d0");


### PR DESCRIPTION
This pull request seeks to remove a redundant `@font-face` declaration from the font CSS template. 

It appears to have been introduced with #246, though it is not entirely clear to me from where it originated. Earlier versions of the [default template from `grunt-webfont`](https://github.com/sapegin/grunt-webfont/blob/master/test/templates/template.css) included similar duplication, but this was later removed in v1.2.0 (March 2016):

https://github.com/sapegin/grunt-webfont/commit/5299f94c7f551b1de0fbe32002dcb835519676f3#diff-391cdceb80b08038931553dfae720a89

The changes proposed here effectively mimic the changes from the above pull request.

**Why**

- The `@font-face` are effectively duplicate, both for the unstyled, default-weighted font of the same family name.
- The remaining `@font-face` still respects browser support for old (read: unsupported) versions of Internet Explorer ([reference](https://css-tricks.com/snippets/css/using-font-face/#article-header-id-0))
- Initial testing shows it to be a remedy for the issue described at https://core.trac.wordpress.org/ticket/47183
- Arguably the EOT format could be dropped altogether, based on [project browser support](https://make.wordpress.org/core/2017/04/23/target-browser-coverage/) (EOT exists for compatibility of Internet Explorer 9 and lower)